### PR TITLE
Setting projection matrix of OrthoCamera. 

### DIFF
--- a/examples/src/main/java/com/monyetmabuk/rajawali/tutorials/examples/general/OrthographicFragment.java
+++ b/examples/src/main/java/com/monyetmabuk/rajawali/tutorials/examples/general/OrthographicFragment.java
@@ -40,6 +40,7 @@ public class OrthographicFragment extends AExampleFragment {
 			int[][] grid;
 
 			orthoCam = new OrthographicCamera();
+			orthoCam.setProjectionMatrix(mViewportWidth, mViewportHeight);
 			getCurrentScene().switchCamera(orthoCam);
 
 			DirectionalLight spotLight = new DirectionalLight(1f, -.1f, -.5f);


### PR DESCRIPTION
RajawaliRenderer sets projection matrix for current camera only.Only on a `onSurfaceChanged`, the camera projection matrix will be updated.