### PR TITLE
update example title when using backbutton also

### DIFF
--- a/examples/src/main/java/com/monyetmabuk/rajawali/tutorials/RajawaliExamplesActivity.java
+++ b/examples/src/main/java/com/monyetmabuk/rajawali/tutorials/RajawaliExamplesActivity.java
@@ -168,15 +168,13 @@ public class RajawaliExamplesActivity extends Activity implements
 		// Close the drawer
 		mDrawerLayout.closeDrawers();
 
-		// Set fragment title
-		setTitle(exampleItem.title);
-
 		final FragmentTransaction transaction = fragmentManager.beginTransaction();
 		try {
 			final Fragment fragment = (Fragment) exampleItem.exampleClass.getConstructors()[0].newInstance();
 
 			final Bundle bundle = new Bundle();
 			bundle.putString(AExampleFragment.BUNDLE_EXAMPLE_URL, exampleItem.getUrl(category));
+			bundle.putString(AExampleFragment.BUNDLE_EXAMPLE_TITLE, exampleItem.title);
 			fragment.setArguments(bundle);
 
 			if (fragmentManager.findFragmentByTag(FRAGMENT_TAG) != null)

--- a/examples/src/main/java/com/monyetmabuk/rajawali/tutorials/examples/AExampleFragment.java
+++ b/examples/src/main/java/com/monyetmabuk/rajawali/tutorials/examples/AExampleFragment.java
@@ -24,11 +24,13 @@ public abstract class AExampleFragment extends RajawaliFragment implements
 		OnClickListener {
 
 	public static final String BUNDLE_EXAMPLE_URL = "BUNDLE_EXAMPLE_URL";
+	public static final String BUNDLE_EXAMPLE_TITLE = "BUNDLE_EXAMPLE_TITLE";
 
 	protected RajawaliRenderer mRenderer;
 	protected ProgressBar mProgressBarLoader;
 	protected GithubLogoView mImageViewExampleLink;
 	protected String mExampleUrl;
+	protected String mExampleTitle;
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
@@ -42,6 +44,7 @@ public abstract class AExampleFragment extends RajawaliFragment implements
 		}
 
 		mExampleUrl = bundle.getString(BUNDLE_EXAMPLE_URL);
+		mExampleTitle = bundle.getString(BUNDLE_EXAMPLE_TITLE);
 
 		if (isTransparentSurfaceView())
 			setGLBackgroundTransparent(true);
@@ -75,6 +78,7 @@ public abstract class AExampleFragment extends RajawaliFragment implements
 				.findViewById(R.id.image_view_example_link);
 		mImageViewExampleLink.setOnClickListener(this);
 
+		getActivity().setTitle(mExampleTitle);
 		return mLayout;
 	}
 


### PR DESCRIPTION
Examples titles are getting updated only on fragment launch. When user switches to previous examples by back button press, the title was not getting updated.